### PR TITLE
RDATE and EXDATE support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ if Mix.env == :dev do
   config :mix_test_watch,
     clear: true,
     tasks: [
-      "test",
+      "coveralls",
       "dialyzer",
       "credo"
     ]

--- a/lib/cocktail.ex
+++ b/lib/cocktail.ex
@@ -6,7 +6,7 @@ defmodule Cocktail do
   creating a new schedule. Details available in the `Cocktail.Schedule` module.
   """
 
-  alias Cocktail.Schedule
+  alias Cocktail.{Schedule, Span}
 
   @type frequency :: :yearly   |
                      :monthly  |
@@ -50,6 +50,8 @@ defmodule Cocktail do
   @type rule_options :: [rule_option]
 
   @type time :: DateTime.t | NaiveDateTime.t
+
+  @type occurrence :: time | Span.t
 
   @doc """
   Creates a new schedule using the given start time and options.

--- a/lib/cocktail/builder/i_calendar.ex
+++ b/lib/cocktail/builder/i_calendar.ex
@@ -40,10 +40,18 @@ defmodule Cocktail.Builder.ICalendar do
       schedule.recurrence_rules
       |> Enum.map(&build_rule/1)
 
+    times =
+      schedule.recurrence_times
+      |> Enum.map(&build_time(&1, "RDATE"))
+
+    exceptions =
+      schedule.exception_times
+      |> Enum.map(&build_time(&1, "EXDATE"))
+
     start_time = build_start_time(schedule.start_time)
     end_time = build_end_time(schedule)
 
-    [start_time] ++ rules ++ [end_time]
+    [start_time] ++ rules ++ times ++ exceptions ++ [end_time]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
   end

--- a/lib/cocktail/builder/json.ex
+++ b/lib/cocktail/builder/json.ex
@@ -2,6 +2,8 @@ defmodule Cocktail.Builder.JSON do
   @moduledoc """
   Build JSON strings and maps from schedules.
 
+  This should be the reverse of `Cocktail.Parser.JSON`.
+
   TODO: write long description
   """
 

--- a/lib/cocktail/builder/string.ex
+++ b/lib/cocktail/builder/string.ex
@@ -1,6 +1,13 @@
 defmodule Cocktail.Builder.String do
   @moduledoc """
   Build human readable strings from schedules.
+
+  This module exposes functions for building human readable string
+  represenations of schedules. It currently only represents the recurrence rules
+  of a schedule, and doesn't indicate the start time, duration, nor any
+  recurrence times or exception times. This is mainly useful for quick glances
+  at schedules in IEx sessions (because it's used for the `inspect`
+  implementation) and for simple doctests.
   """
 
   alias Cocktail.{Rule, Schedule}

--- a/lib/cocktail/parser/i_calendar.ex
+++ b/lib/cocktail/parser/i_calendar.ex
@@ -52,6 +52,8 @@ defmodule Cocktail.Parser.ICalendar do
   defp parse_line("DTSTART" <> time_string, schedule, index), do: parse_dtstart(time_string, schedule, index)
   defp parse_line("DTEND" <> time_string, schedule, index), do: parse_dtend(time_string, schedule, index)
   defp parse_line("RRULE:" <> options_string, schedule, index), do: parse_rrule(options_string, schedule, index)
+  defp parse_line("RDATE" <> time_string, schedule, index), do: parse_rdate(time_string, schedule, index)
+  defp parse_line("EXDATE" <> time_string, schedule, index), do: parse_exdate(time_string, schedule, index)
   defp parse_line(_, _, index), do: {:error, {:unknown_eventprop, index}}
 
   @spec parse_dtstart(String.t, Schedule.t, non_neg_integer) :: {:ok, Schedule.t} | {:error, term}
@@ -328,4 +330,24 @@ defmodule Cocktail.Parser.ICalendar do
   @spec validate_second(integer) :: {:ok, Cocktail.second_number} | :error
   defp validate_second(n) when n >= 0 and n < 60, do: {:ok, n}
   defp validate_second(_), do: :error
+
+  # rdates and exdates
+
+  @spec parse_rdate(String.t, Schedule.t, non_neg_integer) :: {:ok, Schedule.t} | {:error, term}
+  defp parse_rdate(time_string, schedule, index) do
+    with {:ok, datetime} <- parse_datetime(time_string) do
+      {:ok, Schedule.add_recurrence_time(schedule, datetime)}
+    else
+      {:error, term} -> {:error, {term, index}}
+    end
+  end
+
+  @spec parse_exdate(String.t, Schedule.t, non_neg_integer) :: {:ok, Schedule.t} | {:error, term}
+  defp parse_exdate(time_string, schedule, index) do
+    with {:ok, datetime} <- parse_datetime(time_string) do
+      {:ok, Schedule.add_exception_time(schedule, datetime)}
+    else
+      {:error, term} -> {:error, {term, index}}
+    end
+  end
 end

--- a/lib/cocktail/parser/json.ex
+++ b/lib/cocktail/parser/json.ex
@@ -2,6 +2,10 @@ defmodule Cocktail.Parser.JSON do
   @moduledoc """
   Create schedules from JSON strings or maps.
 
+  WIP: this module doesn't currently support the `:count` option, nor does it
+  support recurrence times or exception times.  Also, there's no associated
+  builder yet to actually generate output that this parser would parse.
+
   TODO: write long description
   """
 

--- a/lib/cocktail/schedule.ex
+++ b/lib/cocktail/schedule.ex
@@ -39,11 +39,15 @@ defmodule Cocktail.Schedule do
   """
   @opaque t :: %__MODULE__{
                 recurrence_rules: [Rule.t],
+                recurrence_times: [Cocktail.time],
+                exception_times:  [Cocktail.time],
                 start_time:       Cocktail.time,
                 duration:         pos_integer | nil}
 
-  @enforce_keys [:recurrence_rules, :start_time]
+  @enforce_keys [:start_time]
   defstruct recurrence_rules: [],
+            recurrence_times: [],
+            exception_times:  [],
             start_time:       nil,
             duration:         nil
 
@@ -64,7 +68,10 @@ defmodule Cocktail.Schedule do
   """
   @spec new(Cocktail.time, Cocktail.schedule_options) :: t
   def new(start_time, options \\ []) do
-    %__MODULE__{recurrence_rules: [], start_time: start_time, duration: options[:duration]}
+    %__MODULE__{
+      start_time: start_time,
+      duration: options[:duration]
+    }
   end
 
   @doc false
@@ -125,6 +132,18 @@ defmodule Cocktail.Schedule do
       |> Rule.new
 
     add_recurrence_rule(schedule, rule)
+  end
+
+  # TODO: doc
+  @spec add_recurrence_time(t, Cocktail.time) :: t
+  def add_recurrence_time(%__MODULE__{} = schedule, time) do
+    %{schedule | recurrence_times: [time | schedule.recurrence_times]}
+  end
+
+  # TODO: doc
+  @spec add_exception_time(t, Cocktail.time) :: t
+  def add_exception_time(%__MODULE__{} = schedule, time) do
+    %{schedule | exception_times: [time | schedule.exception_times]}
   end
 
   @doc """

--- a/lib/cocktail/schedule.ex
+++ b/lib/cocktail/schedule.ex
@@ -134,13 +134,24 @@ defmodule Cocktail.Schedule do
     add_recurrence_rule(schedule, rule)
   end
 
-  # TODO: doc
+  @doc """
+  Adds a one-off recurrence time to the schedule.
+
+  This recurrence time can be any time after (or including) the schedule's start
+  time. When generating occurrences from this schedule, the given time will be
+  included in the set of occurrences alongside any recurrence rules.
+  """
   @spec add_recurrence_time(t, Cocktail.time) :: t
   def add_recurrence_time(%__MODULE__{} = schedule, time) do
     %{schedule | recurrence_times: [time | schedule.recurrence_times]}
   end
 
-  # TODO: doc
+  @doc """
+  Adds an exception time to the schedule.
+
+  This exception time will cancel out any occurrence generated from the
+  schedule's recurrence rules or recurrence times.
+  """
   @spec add_exception_time(t, Cocktail.time) :: t
   def add_exception_time(%__MODULE__{} = schedule, time) do
     %{schedule | exception_times: [time | schedule.exception_times]}

--- a/lib/cocktail/schedule.ex
+++ b/lib/cocktail/schedule.ex
@@ -181,10 +181,10 @@ defmodule Cocktail.Schedule do
       # using a DateTime with a time zone
       iex> start_time = Timex.to_datetime(~N[2017-01-02 10:00:00], "America/Los_Angeles")
       ...> schedule = start_time |> new() |> add_recurrence_rule(:daily)
-      ...> schedule |> occurrences() |> Enum.take(3)
-      [Timex.to_datetime(~N[2017-01-02 10:00:00], "America/Los_Angeles"),
-       Timex.to_datetime(~N[2017-01-03 10:00:00], "America/Los_Angeles"),
-       Timex.to_datetime(~N[2017-01-04 10:00:00], "America/Los_Angeles")]
+      ...> schedule |> occurrences() |> Enum.take(3) |> Enum.map(&Timex.format!(&1, "{ISO:Extended}"))
+      ["2017-01-02T10:00:00-08:00",
+       "2017-01-03T10:00:00-08:00",
+       "2017-01-04T10:00:00-08:00"]
 
       # using a NaiveDateTime with a duration
       iex> start_time = ~N[2017-02-01 12:00:00]

--- a/lib/cocktail/schedule_state.ex
+++ b/lib/cocktail/schedule_state.ex
@@ -5,12 +5,16 @@ defmodule Cocktail.ScheduleState do
 
   @type t :: %__MODULE__{
               recurrence_rules: [RuleState.t],
+              recurrence_times: [Cocktail.time],
+              exception_times:  [Cocktail.time],
               start_time:       Cocktail.time,
               current_time:     Cocktail.time,
               duration:         pos_integer | nil}
 
-  @enforce_keys [:recurrence_rules, :start_time, :current_time]
+  @enforce_keys [:start_time, :current_time]
   defstruct recurrence_rules: [],
+            recurrence_times: [],
+            exception_times:  [],
             start_time:       nil,
             current_time:     nil,
             duration:         nil
@@ -20,14 +24,24 @@ defmodule Cocktail.ScheduleState do
   def new(%Schedule{} = schedule, current_time) do
     %__MODULE__{
       recurrence_rules: schedule.recurrence_rules |> Enum.map(&RuleState.new/1),
+      recurrence_times: schedule.recurrence_times |> Enum.sort(&(Timex.compare(&1, &2) <= 0)),
+      exception_times: schedule.exception_times |> Enum.sort(&(Timex.compare(&1, &2) <= 0)),
       start_time: schedule.start_time,
       current_time: current_time,
       duration: schedule.duration
     }
   end
 
-  @spec next_time(t) :: {Cocktail.time | Span.t, t}
+  @spec next_time(t) :: {Cocktail.occurrence, t}
   def next_time(%__MODULE__{} = state) do
+    {time, rules_to_keep} = next_time_from_recurrence_rules(state)
+    {time, times_to_keep} = next_time_from_recurrence_times(state.recurrence_times, time)
+
+    new_state(time, rules_to_keep, times_to_keep, state)
+  end
+
+  # TODO: spec
+  defp next_time_from_recurrence_rules(state) do
     rules_to_keep =
       state.recurrence_rules
       |> Enum.map(&RuleState.next_time(&1, state))
@@ -35,22 +49,33 @@ defmodule Cocktail.ScheduleState do
 
     time = min_time_for_rules(rules_to_keep)
 
-    new_state(time, rules_to_keep, state)
+    {time, rules_to_keep}
   end
 
-  @spec new_state(Cocktail.time, [RuleState.t], t) :: {Cocktail.time | Span.t, t}
-  defp new_state(nil, _, _), do: nil
-  defp new_state(time, rules, state) do
+  # TODO: spec
+  defp next_time_from_recurrence_times([], current_time), do: {current_time, []}
+  defp next_time_from_recurrence_times([next_time | rest] = times, current_time) do
+    if Timex.compare(next_time, current_time) <= 0 do
+      {next_time, rest}
+    else
+      {current_time, times}
+    end
+  end
+
+  @spec new_state(Cocktail.time, [RuleState.t], [Cocktail.time], t) :: {Cocktail.occurrence, t}
+  defp new_state(nil, _, _, _), do: nil
+  defp new_state(time, rules, times, state) do
     output = span_or_time(time, state.duration)
     new_state = %{state |
       recurrence_rules: rules,
+      recurrence_times: times,
       current_time: Timex.shift(time, seconds: 1)
     }
 
     {output, new_state}
   end
 
-  @spec span_or_time(Cocktail.time, pos_integer | nil) :: Cocktail.time | Span.t
+  @spec span_or_time(Cocktail.time, pos_integer | nil) :: Cocktail.occurrence
   defp span_or_time(time, nil), do: time
   defp span_or_time(time, duration), do: Span.new(time, Timex.shift(time, seconds: duration))
 

--- a/lib/cocktail/validation/day.ex
+++ b/lib/cocktail/validation/day.ex
@@ -15,7 +15,7 @@ defmodule Cocktail.Validation.Day do
   @spec next_time(t, Cocktail.time, Cocktail.time) :: Cocktail.Validation.Shift.result
   def next_time(%__MODULE__{day: day}, time, _) do
     diff = day - Timex.weekday(time) |> mod(7)
-    shift_by_bod(diff, :days, time)
+    shift_by(diff, :days, time, :beginning_of_day)
   end
 
   @spec day_number(Cocktail.day) :: Cocktail.day_number

--- a/lib/cocktail/validation/hour_of_day.ex
+++ b/lib/cocktail/validation/hour_of_day.ex
@@ -15,7 +15,6 @@ defmodule Cocktail.Validation.HourOfDay do
   @spec next_time(t, Cocktail.time, Cocktail.time) :: Cocktail.Validation.Shift.result
   def next_time(%__MODULE__{hour: hour}, time, _) do
     diff = hour - time.hour |> mod(24)
-    shift_by(diff, :hours, time)
-    # TODO: this might also need a "beginning of hour" on it like `day.ex`
+    shift_by(diff, :hours, time, :beginning_of_hour)
   end
 end

--- a/lib/cocktail/validation/minute_of_hour.ex
+++ b/lib/cocktail/validation/minute_of_hour.ex
@@ -15,7 +15,6 @@ defmodule Cocktail.Validation.MinuteOfHour do
   @spec next_time(t, Cocktail.time, Cocktail.time) :: Cocktail.Validation.Shift.result
   def next_time(%__MODULE__{minute: minute}, time, _) do
     diff = minute - time.minute |> mod(60)
-    shift_by(diff, :minutes, time)
-    # TODO: this might also need a "beginning of minute" on it like `day.ex`
+    shift_by(diff, :minutes, time, :beginning_of_minute)
   end
 end

--- a/lib/cocktail/validation/shift.ex
+++ b/lib/cocktail/validation/shift.ex
@@ -7,13 +7,25 @@ defmodule Cocktail.Validation.Shift do
 
   @typep shift_type :: :days | :hours | :minutes | :seconds
 
+  @typep option :: nil | :beginning_of_day | :beginning_of_hour | :beginning_of_minute
+
   import Timex, only: [shift: 2, beginning_of_day: 1]
 
-  @spec shift_by(integer, shift_type, Cocktail.time) :: result
-  def shift_by(0, _, time), do: {:no_change, time}
-  def shift_by(amount, type, time), do: {:updated, shift(time, "#{type}": amount)}
+  @spec shift_by(integer, shift_type, Cocktail.time, option) :: result
+  def shift_by(amount, type, time, option \\ nil)
+  def shift_by(0, _, time, _), do: {:no_change, time}
+  def shift_by(amount, type, time, option) do
+    new_time =
+      time
+      |> shift("#{type}": amount)
+      |> apply_option(option)
 
-  @spec shift_by_bod(integer, shift_type, Cocktail.time) :: result
-  def shift_by_bod(0, _, time), do: {:no_change, time}
-  def shift_by_bod(amount, type, time), do: {:updated, time |> shift("#{type}": amount) |> beginning_of_day()}
+    {:updated, new_time}
+  end
+
+  @spec apply_option(Cocktail.time, option) :: Cocktail.time
+  defp apply_option(time, nil), do: time
+  defp apply_option(time, :beginning_of_day), do: time |> beginning_of_day()
+  defp apply_option(time, :beginning_of_hour), do: %{time | minute: 0, second: 0, microsecond: {0, 0}}
+  defp apply_option(time, :beginning_of_minute), do: %{time | second: 0, microsecond: {0, 0}}
 end

--- a/test/cocktail/reversibility_test.exs
+++ b/test/cocktail/reversibility_test.exs
@@ -1,0 +1,85 @@
+defmodule Cocktail.ReversibilityTest do
+  use ExUnit.Case
+
+  alias Cocktail.Schedule
+
+  defp assert_reversible(schedule) do
+    i_calendar_string = Schedule.to_i_calendar(schedule)
+    {:ok, parsed_schedule} = Schedule.from_i_calendar(i_calendar_string)
+
+    assert parsed_schedule == schedule
+  end
+
+  for frequency <- [:secondly, :minutely, :hourly, :daily, :weekly] do
+    test "#{frequency}" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency))
+      |> assert_reversible()
+    end
+
+    test "#{frequency} interval 2" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), interval: 2)
+      |> assert_reversible()
+    end
+
+    test "#{frequency} on Mondays, Wednesdays and Fridays" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), days: [:monday, :wednesday, :friday])
+      |> assert_reversible()
+    end
+
+    test "#{frequency} on the 10th, 12th and 14th hours of the day" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), hours: [10, 12, 14])
+      |> assert_reversible()
+    end
+
+    test "#{frequency} on the 0th and 30th minutes of the hour" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), minutes: [0, 30])
+      |> assert_reversible()
+    end
+
+    test "#{frequency} on the 0th and 30th seconds of the minute" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), seconds: [0, 30])
+      |> assert_reversible()
+    end
+
+    test "#{frequency} until someday" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), until: ~N[2017-10-09 09:00:00])
+      |> assert_reversible()
+    end
+
+    test "#{frequency} 10 times" do
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(unquote(frequency), count: 10)
+      |> assert_reversible()
+    end
+  end
+
+  test "recurrence times" do
+    ~N[2017-09-09 09:00:00]
+    |> Schedule.new
+    |> Schedule.add_recurrence_time(~N[2017-10-09 09:00:00])
+    |> assert_reversible()
+  end
+
+  test "exception times" do
+    ~N[2017-09-09 09:00:00]
+    |> Schedule.new
+    |> Schedule.add_recurrence_rule(:daily)
+    |> Schedule.add_exception_time(~N[2017-09-10 09:00:00])
+    |> assert_reversible()
+  end
+end

--- a/test/cocktail/schedule_test.exs
+++ b/test/cocktail/schedule_test.exs
@@ -27,4 +27,35 @@ defmodule Cocktail.ScheduleTest do
 
     assert length(times) == 23
   end
+
+  test "an empty schedule produces a single occurrence at its start time" do
+    schedule = ~N[2017-09-09 09:00:00] |> Schedule.new
+    times = schedule |> Schedule.occurrences |> Enum.to_list
+
+    assert times == [~N[2017-09-09 09:00:00]]
+  end
+
+  test "recurrence times" do
+    schedule =
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_time(~N[2017-09-09 09:00:00])
+      |> Schedule.add_recurrence_time(~N[2017-09-10 09:00:00])
+
+    times = schedule |> Schedule.occurrences |> Enum.to_list
+
+    assert times == [~N[2017-09-09 09:00:00], ~N[2017-09-10 09:00:00]]
+  end
+
+  test "exception times" do
+    schedule =
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new
+      |> Schedule.add_recurrence_rule(:daily)
+      |> Schedule.add_exception_time(~N[2017-09-10 09:00:00])
+
+    times = schedule |> Schedule.occurrences |> Enum.take(2)
+
+    assert times == [~N[2017-09-09 09:00:00], ~N[2017-09-11 09:00:00]]
+  end
 end


### PR DESCRIPTION
* support one-off recurrence times (RDATE)
* support exception times (EXDATE)
* an empty schedule will now always at least return one occurrence (its start time)
* parsing and building support for the above
* tests and docs for the above