### PR TITLE
Add a new proprietary extension: X-BYRANGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
+### Breaking
+-   The `BYTIME` option of `RRULE`s in the iCalendar output is now `X-BYTIME` to better follow the standard's extensions policy
+
+### Added
+-   "time range" option (e.g. `Schedule.add_recurrence_rules(:daily, time_range: %{start_time: ~T[09:00:00], end_time: ~T[11:00:00], interval_seconds: 1_800})`; this serializes to `X-BYRANGE` in iCalendar format, using the extension prefix to signal that it's a proprietary extension)
+
 ### Changed
 -   Formatted code-base with the new Elixir 1.6 code formatter
 -   Changed `Schedule.t()` to not be an opaque type, which fixed the few missing typespecs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ by adding `cocktail` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:cocktail, "~> 0.7"}
+    {:cocktail, "~> 0.8"}
   ]
 end
 ```

--- a/lib/cocktail.ex
+++ b/lib/cocktail.ex
@@ -22,6 +22,12 @@ defmodule Cocktail do
 
   @type second_number :: 0..59
 
+  @type time_range :: %{
+          start_time: Time.t(),
+          end_time: Time.t(),
+          interval_seconds: second_number()
+        }
+
   @type schedule_option :: {:duration, pos_integer}
 
   @type schedule_options :: [schedule_option]
@@ -36,6 +42,7 @@ defmodule Cocktail do
           | {:minutes, [minute_number]}
           | {:seconds, [second_number]}
           | {:times, [Time.t()]}
+          | {:time_range, time_range}
 
   @type rule_options :: [rule_option]
 

--- a/lib/cocktail/builder/i_calendar.ex
+++ b/lib/cocktail/builder/i_calendar.ex
@@ -201,6 +201,6 @@ defmodule Cocktail.Builder.ICalendar do
       end)
       |> Enum.join(",")
 
-    "BYTIME=#{times_list}"
+    "X-BYTIME=#{times_list}"
   end
 end

--- a/lib/cocktail/builder/i_calendar.ex
+++ b/lib/cocktail/builder/i_calendar.ex
@@ -6,7 +6,7 @@ defmodule Cocktail.Builder.ICalendar do
   """
 
   alias Cocktail.{Rule, Schedule, Validation}
-  alias Cocktail.Validation.{Interval, Day, HourOfDay, MinuteOfHour, SecondOfMinute, TimeOfDay}
+  alias Cocktail.Validation.{Interval, Day, HourOfDay, MinuteOfHour, SecondOfMinute, TimeOfDay, TimeRange}
 
   @time_format_string "{YYYY}{0M}{0D}T{h24}{m}{s}"
 
@@ -92,7 +92,7 @@ defmodule Cocktail.Builder.ICalendar do
   @spec build_rule(Rule.t()) :: String.t()
   defp build_rule(%Rule{validations: validations_map, until: until, count: count}) do
     parts =
-      for key <- [:interval, :day, :hour_of_day, :minute_of_hour, :second_of_minute, :time_of_day],
+      for key <- [:interval, :day, :hour_of_day, :minute_of_hour, :second_of_minute, :time_of_day, :time_range],
           validation = validations_map[key],
           !is_nil(validation) do
         build_validation_part(key, validation)
@@ -110,6 +110,7 @@ defmodule Cocktail.Builder.ICalendar do
   defp build_validation_part(:minute_of_hour, %MinuteOfHour{minutes: minutes}), do: minutes |> build_minutes()
   defp build_validation_part(:second_of_minute, %SecondOfMinute{seconds: seconds}), do: seconds |> build_seconds()
   defp build_validation_part(:time_of_day, %TimeOfDay{times: times}), do: times |> build_times()
+  defp build_validation_part(:time_range, %TimeRange{} = time_range), do: time_range |> build_time_range()
 
   @spec build_until(Cocktail.time() | nil) :: [String.t()]
   defp build_until(nil), do: []
@@ -193,14 +194,26 @@ defmodule Cocktail.Builder.ICalendar do
     times_list =
       times
       |> Enum.sort()
-      |> Enum.map(fn {hour, min, sec} ->
-        hours = String.pad_leading("#{hour}", 2, "0")
-        mins = String.pad_leading("#{min}", 2, "0")
-        secs = String.pad_leading("#{sec}", 2, "0")
-        "#{hours}#{mins}#{secs}"
-      end)
+      |> Enum.map(&format_erl_time/1)
       |> Enum.join(",")
 
     "X-BYTIME=#{times_list}"
   end
+
+  defp format_erl_time({hour, min, sec}) do
+    hours = String.pad_leading("#{hour}", 2, "0")
+    mins = String.pad_leading("#{min}", 2, "0")
+    secs = String.pad_leading("#{sec}", 2, "0")
+
+    "#{hours}#{mins}#{secs}"
+  end
+
+  # "time range" validation
+
+  @spec build_time_range(TimeRange.t()) :: String.t()
+  defp build_time_range(%TimeRange{start_time: start_time, end_time: end_time, interval_seconds: interval}) do
+    "X-BYRANGE=" <> ([format_time(start_time), format_time(end_time), interval] |> Enum.join(","))
+  end
+
+  defp format_time(time), do: time |> Time.to_erl() |> format_erl_time
 end

--- a/lib/cocktail/parser/i_calendar.ex
+++ b/lib/cocktail/parser/i_calendar.ex
@@ -183,7 +183,7 @@ defmodule Cocktail.Parser.ICalendar do
     end
   end
 
-  defp parse_rrule_option("BYTIME=" <> times_string) do
+  defp parse_rrule_option("X-BYTIME=" <> times_string) do
     with {:ok, times} <- parse_times_string(times_string) do
       {:ok, {:times, times |> Enum.reverse()}}
     end

--- a/lib/cocktail/rule_state.ex
+++ b/lib/cocktail/rule_state.ex
@@ -24,6 +24,7 @@ defmodule Cocktail.RuleState do
     :base_hour,
     :hour_of_day,
     :time_of_day,
+    :time_range,
     :base_wday,
     :day,
     :interval

--- a/lib/cocktail/validation.ex
+++ b/lib/cocktail/validation.ex
@@ -8,7 +8,8 @@ defmodule Cocktail.Validation do
     HourOfDay,
     MinuteOfHour,
     SecondOfMinute,
-    TimeOfDay
+    TimeOfDay,
+    TimeRange
   }
 
   @type validation_key ::
@@ -21,6 +22,7 @@ defmodule Cocktail.Validation do
           | :minute_of_hour
           | :second_of_minute
           | :time_of_day
+          | :time_range
           | :interval
 
   @type validations_map :: %{validation_key => t}
@@ -33,6 +35,7 @@ defmodule Cocktail.Validation do
           | MinuteOfHour.t()
           | SecondOfMinute.t()
           | TimeOfDay.t()
+          | TimeRange.t()
 
   @spec build_validations(Cocktail.rule_options()) :: validations_map
   def build_validations(options) do
@@ -122,6 +125,15 @@ defmodule Cocktail.Validation do
     |> Map.delete(:base_min)
     |> Map.delete(:base_hour)
     |> Map.put(:time_of_day, TimeOfDay.new(times))
+    |> apply_options(rest)
+  end
+
+  defp apply_options(map, [{:time_range, time_range} | rest]) do
+    map
+    |> Map.delete(:base_sec)
+    |> Map.delete(:base_min)
+    |> Map.delete(:base_hour)
+    |> Map.put(:time_range, TimeRange.new(time_range))
     |> apply_options(rest)
   end
 

--- a/lib/cocktail/validation/time_range.ex
+++ b/lib/cocktail/validation/time_range.ex
@@ -1,0 +1,45 @@
+defmodule Cocktail.Validation.TimeRange do
+  @moduledoc false
+
+  alias Cocktail.Validation.TimeOfDay
+
+  @type t :: %__MODULE__{
+          start_time: Time.t(),
+          end_time: Time.t(),
+          interval_seconds: Cocktail.second_number(),
+          time_of_day: TimeOfDay.t()
+        }
+
+  @enforce_keys [:start_time, :end_time, :interval_seconds]
+  defstruct start_time: nil,
+            end_time: nil,
+            interval_seconds: nil,
+            time_of_day: nil
+
+  @spec new(Cocktail.time_range()) :: t()
+  def new(attrs) do
+    time_range = struct!(__MODULE__, attrs)
+    times = generate_times(time_range)
+
+    %{time_range | time_of_day: TimeOfDay.new(times)}
+  end
+
+  @spec generate_times(t()) :: [Time.t()]
+  defp generate_times(%__MODULE__{} = time_range) do
+    time_range.start_time
+    |> Stream.unfold(fn time ->
+      case Time.compare(time, time_range.end_time) do
+        :gt ->
+          nil
+
+        _ ->
+          {time, Time.add(time, time_range.interval_seconds)}
+      end
+    end)
+    |> Enum.to_list()
+  end
+
+  @spec next_time(t(), Cocktail.time(), Cocktail.time()) :: Cocktail.Validation.Shift.result()
+  def next_time(%__MODULE__{time_of_day: time_of_day}, time, start_time),
+    do: TimeOfDay.next_time(time_of_day, time, start_time)
+end

--- a/lib/cocktail/validation/time_range.ex
+++ b/lib/cocktail/validation/time_range.ex
@@ -46,7 +46,7 @@ defmodule Cocktail.Validation.TimeRange do
   if Version.compare(System.version(), "1.6.0") == :lt do
     # Yanked from Elixir 1.6.1 source code.  Remove once we drop support for Elixir < 1.6.
     @spec time_add(Calendar.time(), integer, System.time_unit()) :: t
-    def time_add(%{calendar: calendar} = time, number, unit \\ :second) when is_integer(number) do
+    defp time_add(%{calendar: calendar} = time, number, unit \\ :second) when is_integer(number) do
       number = System.convert_time_unit(number, unit, :microsecond)
       iso_days = {0, to_day_fraction(time)}
       total = Calendar.ISO.iso_days_to_unit(iso_days, :microsecond) + number
@@ -74,6 +74,6 @@ defmodule Cocktail.Validation.TimeRange do
       calendar.time_to_day_fraction(hour, minute, second, microsecond)
     end
   else
-    def time_add(time, amount, unit \\ :second), do: Time.add(time, amount, unit)
+    defp time_add(time, amount, unit \\ :second), do: Time.add(time, amount, unit)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cocktail.Mixfile do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,6 @@ defmodule Cocktail.Mixfile do
       {:excoveralls, "~> 0.7", only: :test},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:mix_test_watch, "~> 0.3", only: :dev, runtime: false},
-      {:poison, ">= 2.0.0"},
       {:timex, "~> 3.1"}
     ]
   end

--- a/test/cocktail/reversibility_test.exs
+++ b/test/cocktail/reversibility_test.exs
@@ -90,6 +90,16 @@ defmodule Cocktail.ReversibilityTest do
     |> assert_reversible()
   end
 
+  test "time range option" do
+    ~N[2017-09-09 09:00:00]
+    |> Schedule.new()
+    |> Schedule.add_recurrence_rule(
+      :daily,
+      time_range: %{start_time: ~T[09:00:00], end_time: ~T[11:00:00], interval_seconds: 1_800}
+    )
+    |> assert_reversible()
+  end
+
   test "empty days" do
     ~N[2017-09-09 09:00:00] |> Schedule.new() |> Schedule.add_recurrence_rule(:daily, days: []) |> assert_reversible()
   end

--- a/test/cocktail/validation/time_range_test.exs
+++ b/test/cocktail/validation/time_range_test.exs
@@ -1,0 +1,50 @@
+defmodule Cocktail.TimeRangeTest do
+  use ExUnit.Case
+
+  alias Cocktail.{Schedule}
+
+  import Cocktail.TestSupport.DateTimeSigil
+
+  test "a daily schedule with a time range option" do
+    schedule =
+      ~N[2017-09-09 09:00:00]
+      |> Schedule.new()
+      |> Schedule.add_recurrence_rule(
+        :daily,
+        time_range: %{start_time: ~T[09:00:00], end_time: ~T[11:00:00], interval_seconds: 1_800}
+      )
+
+    times = schedule |> Schedule.occurrences() |> Enum.take(6)
+
+    assert times == [
+             ~N[2017-09-09 09:00:00],
+             ~N[2017-09-09 09:30:00],
+             ~N[2017-09-09 10:00:00],
+             ~N[2017-09-09 10:30:00],
+             ~N[2017-09-09 11:00:00],
+             ~N[2017-09-10 09:00:00]
+           ]
+  end
+
+  test "a daily schedule with a zoned datetime and a time range option" do
+    schedule =
+      ~N[2017-09-09 09:00:00]
+      |> Timex.to_datetime("America/Chicago")
+      |> Schedule.new()
+      |> Schedule.add_recurrence_rule(
+        :daily,
+        time_range: %{start_time: ~T[09:00:00], end_time: ~T[11:00:00], interval_seconds: 1_800}
+      )
+
+    times = schedule |> Schedule.occurrences() |> Enum.take(6)
+
+    assert times == [
+             ~Y[2017-09-09 09:00:00 America/Chicago],
+             ~Y[2017-09-09 09:30:00 America/Chicago],
+             ~Y[2017-09-09 10:00:00 America/Chicago],
+             ~Y[2017-09-09 10:30:00 America/Chicago],
+             ~Y[2017-09-09 11:00:00 America/Chicago],
+             ~Y[2017-09-10 09:00:00 America/Chicago]
+           ]
+  end
+end


### PR DESCRIPTION
Allows specifying schedules that have a range of occurrences within a day, e.g.: "Every 30 minutes between 9am and 2pm, weekly on Mondays, Wednesdays and Fridays"