### PR TITLE
Allow additional keys in Cocktail.Span.span_compat type

### DIFF
--- a/lib/cocktail/span.ex
+++ b/lib/cocktail/span.ex
@@ -12,7 +12,7 @@ defmodule Cocktail.Span do
 
   @type t :: %__MODULE__{from: Cocktail.time(), until: Cocktail.time()}
 
-  @type span_compat :: %{from: Cocktail.time(), until: Cocktail.time()}
+  @type span_compat :: %{:from => Cocktail.time(), :until => Cocktail.time(), optional(atom) => any}
 
   @type overlap_mode ::
           :contains


### PR DESCRIPTION
The `span_compat` type in the Coctail.Span module was restricting what other keys were allowed in the map being passed into functions.  This PR remotes that restriction.