### PR TITLE
Fix bug in Builder.String when there's only a single day

### DIFF
--- a/lib/cocktail/builder/string.ex
+++ b/lib/cocktail/builder/string.ex
@@ -137,6 +137,9 @@ defmodule Cocktail.Builder.String do
   # utils
 
   @spec sentence([String.t()]) :: String.t()
+  defp sentence([single]), do: single
+
+  @spec sentence([String.t()]) :: String.t()
   defp sentence([first, second]), do: "#{first} and #{second}"
 
   defp sentence(words) do

--- a/test/cocktail/builder/string_test.exs
+++ b/test/cocktail/builder/string_test.exs
@@ -16,6 +16,17 @@ defmodule Cocktail.Builder.StringTest do
     assert string == "Weekly on Mondays, Wednesdays and Fridays"
   end
 
+  test "build a schedule with a BYDAY option, with only a single day" do
+    schedule =
+      ~N[2017-01-01 09:00:00]
+      |> Cocktail.schedule()
+      |> Schedule.add_recurrence_rule(:weekly, days: [:monday])
+
+    string = Schedule.to_string(schedule)
+
+    assert string == "Weekly on Mondays"
+  end
+
   test "build a schedule with a BYHOUR option" do
     schedule =
       ~N[2017-01-01 09:00:00]


### PR DESCRIPTION
When building a readable string from the rule `Schedule.add_recurrence_rule(:weekly, days: [:monday])` the resulting string becomes "Weekly on  and Mondays". 

I've added a test and fixed the bug.

Please comment if there's anything you would prefer I do differently