### PR TITLE
Expose Rule to docs

### DIFF
--- a/lib/cocktail/rule.ex
+++ b/lib/cocktail/rule.ex
@@ -1,4 +1,8 @@
 defmodule Cocktail.Rule do
+  @moduledoc """
+  Represent a recurrence rule (RRULE).
+  """
+
   alias Cocktail.{Builder, Rule, Validation}
 
   @type t :: %__MODULE__{

--- a/lib/cocktail/rule.ex
+++ b/lib/cocktail/rule.ex
@@ -1,6 +1,4 @@
 defmodule Cocktail.Rule do
-  @moduledoc false
-
   alias Cocktail.{Builder, Rule, Validation}
 
   @type t :: %__MODULE__{


### PR DESCRIPTION
`Cocktail.Rule.t()` is being used in multiple places, therefore we need to expose `Cocktail.Rule` in order to see the documentation of the type.

![Screen Shot 2021-05-09 at 8 11 41 PM](https://user-images.githubusercontent.com/4237280/117591494-a1010800-b0e9-11eb-86c6-8c40e6f299ca.png)
