### PR TITLE
fix: infinite loop at Cocktail.Validation.TimeRange.generate_times/1

### DIFF
--- a/lib/cocktail/validation/time_range.ex
+++ b/lib/cocktail/validation/time_range.ex
@@ -28,12 +28,19 @@ defmodule Cocktail.Validation.TimeRange do
   defp generate_times(%__MODULE__{} = time_range) do
     time_range.start_time
     |> Stream.unfold(fn time ->
-      case Time.compare(time, time_range.end_time) do
-        :gt ->
+      current_gt_end = Time.compare(time, time_range.end_time)
+      next_time = Time.add(time, time_range.interval_seconds)
+      current_gt_next = Time.compare(time, next_time)
+
+      case {current_gt_end, current_gt_next} do
+        {:gt, _} ->
+          nil
+
+        {_, :gt} ->
           nil
 
         _ ->
-          {time, Time.add(time, time_range.interval_seconds)}
+          {time, next_time}
       end
     end)
     |> Enum.to_list()

--- a/test/cocktail/schedule_test.exs
+++ b/test/cocktail/schedule_test.exs
@@ -71,22 +71,20 @@ defmodule Cocktail.ScheduleTest do
   end
 
   test "occurrences at the end of the day won't cause an infinite loop" do
-    times =
-      ~N[2021-10-15 23:00:00]
-      |> Schedule.new(duration: 1800)
-      |> Schedule.add_recurrence_rule(
-        :daily,
-        time_range: %{
-          start_time: ~T[23:00:00],
-          end_time: ~T[23:55:00],
-          interval_seconds: 1800
-        },
-        until: ~N[2021-10-15 23:55:00]
-      )
-      |> Schedule.occurrences()
-      |> Enum.to_list()
-
-    assert times == [~N[2017-09-09 09:00:00]]
+    assert [%{from: ~N[2021-10-15 23:00:00], until: ~N[2021-10-15 23:30:00]}] =
+             ~N[2021-10-15 23:00:00]
+             |> Schedule.new(duration: 1800)
+             |> Schedule.add_recurrence_rule(
+               :daily,
+               time_range: %{
+                 start_time: ~T[23:00:00],
+                 end_time: ~T[23:55:00],
+                 interval_seconds: 1800
+               },
+               until: ~N[2021-10-15 23:55:00]
+             )
+             |> Schedule.occurrences()
+             |> Enum.to_list()
   end
 
   test "add recurrence rule with bad options" do


### PR DESCRIPTION
This PR aims to fix the issue described in the original PR.