### PR TITLE
Handle EXDATE with a comma separated list of datetimes

### DIFF
--- a/test/cocktail/parser/i_calendar_test.exs
+++ b/test/cocktail/parser/i_calendar_test.exs
@@ -139,6 +139,30 @@ defmodule Cocktail.Parser.ICalendarTest do
     assert datetime == ~N[2017-01-01 06:00:00]
   end
 
+  test "parses a schedule with an EXDATE list" do
+    schedule_string = """
+    DTSTART:20170101T060000
+    EXDATE:20170101T060000,20170102T060000
+    """
+
+    assert {:ok, schedule} = parse(schedule_string)
+    assert [%NaiveDateTime{} = first_datetime, %NaiveDateTime{} = second_datetime] = schedule.exception_times
+    assert first_datetime == ~N[2017-01-01 06:00:00]
+    assert second_datetime == ~N[2017-01-02 06:00:00]
+  end
+
+  test "parses a schedule with an EXDATE list and a TZID" do
+    schedule_string = """
+    DTSTART;TZID=America/Los_Angeles:20170101T060000
+    EXDATE;TZID=America/Los_Angeles:20170101T060000,20170102T060000
+    """
+
+    assert {:ok, schedule} = parse(schedule_string)
+    assert [%DateTime{} = first_datetime, %DateTime{} = second_datetime] = schedule.exception_times
+    assert first_datetime == ~Y[2017-01-01 06:00:00 America/Los_Angeles]
+    assert second_datetime == ~Y[2017-01-02 06:00:00 America/Los_Angeles]
+  end
+
   ##########
   # Errors #
   ##########


### PR DESCRIPTION
Hi,

First of all, thank you for this library!
We're currently using your previous one, ExCal, to handle recurring events.
Since compatibility between NIF and Apple M1 chips is hard, we're switching to Cocktail.
The only issue we've met is with EXDATE.
According to the iCal specs, we should be able to use it with a list of datetimes, which is currently not supported by Cocktail.
This PR adds this support

Thanks!