### PR TITLE
Fix compilation error with Elixir 1.14

### DIFF
--- a/lib/cocktail/rule.ex
+++ b/lib/cocktail/rule.ex
@@ -28,7 +28,7 @@ defmodule Cocktail.Rule do
   @spec set_until(t, Cocktail.time()) :: t
   def set_until(%__MODULE__{} = rule, end_time), do: %{rule | until: end_time}
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Inspect do
     import Inspect.Algebra
 
     def inspect(rule, _) do

--- a/lib/cocktail/schedule.ex
+++ b/lib/cocktail/schedule.ex
@@ -248,7 +248,7 @@ defmodule Cocktail.Schedule do
   defp no_ms(nil), do: nil
   defp no_ms(time), do: %{time | microsecond: {0, 0}}
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Inspect do
     import Inspect.Algebra
 
     def inspect(schedule, _) do


### PR DESCRIPTION
Since Elixir 1.14, the following results in a compilation error

```elixir
defmodule Cocktail.Schedule do
  ...
  defimpl Inspect, for: __MODULE__ do
    ...
  end
end
```

Error looks like this:

```
==> cocktail
Compiling 21 files (.ex)

== Compilation error in file lib/cocktail/schedule.ex ==
** (CompileError) lib/cocktail/schedule.ex:251: cannot define module
Inspect.Kernel because it is currently being defined in
lib/cocktail/rule.ex:31
    lib/cocktail/schedule.ex:251: (module)
```

I checked the docs for a few Elixir versions back (at least 1.10), and they always said

> When implementing a protocol for a struct, the :for option can be
> omitted if the defimpl call is inside the module that defines the struct

This patch removes the unnecessary `for: __MODULE__` option to fix the compilation error.

---

Just FYI: It looks to me like a bug in Elixir 1.14, but I failed to reproduce it outside cocktail. It's not just the `for: __MODULE__` by itself, at least. Unfortunately I don't really have the time to dig deeper right now. So if you could apply this patch, I'd be very grateful :)